### PR TITLE
Calculate normal after creating vertices

### DIFF
--- a/js/objects.js
+++ b/js/objects.js
@@ -198,9 +198,6 @@ meshObject.prototype.getScene = function () {
 };
 meshObject.prototype.createMeshObject = function () {
     geometry = new THREE.Geometry();
-    geometry.computeFaceNormals();
-    geometry.computeVertexNormals();
-    geometry.computeCentroids();
     geometry.dynamic = true;
     step = 0.05;
     var q = parseInt(2 * Math.PI / step + 1.3462);
@@ -246,6 +243,9 @@ meshObject.prototype.createMeshObject = function () {
             geometry.faces.push(new THREE.Face4(d, c, b, a))
         }
     }
+    geometry.computeFaceNormals();
+    geometry.computeVertexNormals();
+    geometry.computeCentroids();
 };
 meshObject.prototype.createMeshMaterial = function () {
     material = new THREE.MeshLambertMaterial();


### PR DESCRIPTION
Hi I've played with your code and wonder why there the normlas available in the shader are always 0. After digging into your code I recognize that you create the normals before you create the vertices, this could not work. 
